### PR TITLE
Make Aioli code valid ES6

### DIFF
--- a/aioli.js
+++ b/aioli.js
@@ -5,13 +5,18 @@
 
 class Aioli
 {
-    // Module
-    ready = false;      // Will be true when the module is ready
-    urlModule = "";     // URL path to module
-    // WebWorker
-    worker = null;      // WebWorker this module communicates with
-    resolves = {};      // Track Promise functions for each message we send to the Worker
-    rejects = {};
+    // =========================================================================
+    // Properties
+    // =========================================================================
+
+    // Module:
+    //  ready = false;      // Will be true when the module is ready
+    //  urlModule = "";     // URL path to module
+
+    // WebWorker:
+    //  worker = null;      // WebWorker this module communicates with
+    //  resolves = {};      // Track Promise functions for each message we send to the Worker
+    //  rejects = {};
 
     // =========================================================================
     // Configs and defaults
@@ -37,6 +42,13 @@ class Aioli
     // e.g. Aioli("samtools/1.10") --> cdn.sandbox.bio/samtools/1.10/worker.{js,wasm}
     constructor(module)
     {
+        // Initialize properties
+        this.ready = false;
+        this.urlModule = "";
+        this.worker = null;
+        this.resolves = {};
+        this.rejects = {};
+
         // Input validation
         if(typeof module != "string")
             throw "Must provide a string to the Aioli constructor";

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robertaboukhalil/aioli",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "A framework for building WebAssembly-based genomics tools",
   "main": "aioli.js",
   "repository": {


### PR DESCRIPTION
Was using class properties, which are not valid ES6. This PR moves initializing class properties to the constructor.